### PR TITLE
Use standard C function rand

### DIFF
--- a/example.c
+++ b/example.c
@@ -16,7 +16,7 @@ TEST example_test_case(void) {
     int r = 0;
     ASSERT(1 == 1);
 
-    r = random() % 10;
+    r = rand() % 10;
     if (r == 1) SKIP();
     ASSERT(r >= 1);
     PASS();


### PR DESCRIPTION
I was trying to compile the example with Visual C++, and it complained about the use of `random()`. I changed it to use the standard C library function `rand()`.
