### PR TITLE
Add a package.json file for clib(1) support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greatest",
-  "version": "0.0.0",
+  "version": "v0.9.3",
   "repo": "silentbicycle/greatest",
   "src": ["greatest.h"],
   "description": "A C unit testing library in 1 file. No dependencies, no dynamic allocation",


### PR DESCRIPTION
A package.json file allows clib(1) to install this lib and index it in its registry.

See [clib](https://github.com/clibs/clib) for more.
