### PR TITLE
A collection of bug fixes

### DIFF
--- a/greatest.h
+++ b/greatest.h
@@ -223,7 +223,6 @@ void greatest_do_pass(const char *name);
 void greatest_do_fail(const char *name);
 void greatest_do_skip(const char *name);
 int greatest_pre_test(const char *name);
-int greatest_save_context(void);
 void greatest_post_test(const char *name, int res);
 void greatest_usage(const char *name);
 int greatest_do_assert_equal_t(const void *exp, const void *got,
@@ -260,7 +259,7 @@ typedef enum {
 #define GREATEST_RUN_TEST(TEST)                                         \
     do {                                                                \
         if (greatest_pre_test(#TEST) == 1) {                            \
-            greatest_test_res res = greatest_save_context();            \
+            greatest_test_res res = GREATEST_SAVE_CONTEXT();            \
             if (res == GREATEST_TEST_RES_PASS) {                        \
                 res = TEST();                                           \
             }                                                           \
@@ -433,18 +432,14 @@ typedef enum {
         (double)((C2) - (C1)) / (1.0 * (double)CLOCKS_PER_SEC))         \
 
 #if GREATEST_USE_LONGJMP
-#define GREATEST_MAIN_DEFS_SAVE_CONTEXT()                               \
-    greatest_test_res greatest_save_context(void) {                     \
+#define GREATEST_SAVE_CONTEXT()                                         \
         /* setjmp returns 0 (GREATEST_TEST_RES_PASS) on first call */   \
         /* so the test runs, then RES_FAIL from FAIL_WITH_LONGJMP. */   \
-        return (greatest_test_res)(setjmp(greatest_info.jump_dest));    \
-    }
+        ((greatest_test_res)(setjmp(greatest_info.jump_dest)))
 #else
-#define GREATEST_MAIN_DEFS_SAVE_CONTEXT()                               \
-    greatest_test_res greatest_save_context(void) {                     \
-        /*a no-op, since setjmp/longjmp aren't being used */            \
-        return GREATEST_TEST_RES_PASS;                                  \
-    }
+#define GREATEST_SAVE_CONTEXT()                                         \
+    /*a no-op, since setjmp/longjmp aren't being used */                \
+    GREATEST_TEST_RES_PASS
 #endif
 
 /* Include several function definitions in the main test file. */
@@ -481,8 +476,6 @@ int greatest_pre_test(const char *name) {                               \
         return 0;               /* skipped */                           \
     }                                                                   \
 }                                                                       \
-                                                                        \
-GREATEST_MAIN_DEFS_SAVE_CONTEXT()                                       \
                                                                         \
 void greatest_post_test(const char *name, int res) {                    \
     GREATEST_SET_TIME(greatest_info.suite.post_test);                   \

--- a/greatest.h
+++ b/greatest.h
@@ -209,13 +209,6 @@ typedef struct greatest_run_info {
 #endif
 } greatest_run_info;
 
-/* PASS/FAIL/SKIP result from a test. Used internally. */
-typedef enum {
-    GREATEST_TEST_RES_PASS = 0,
-    GREATEST_TEST_RES_FAIL = -1,
-    GREATEST_TEST_RES_SKIP = 1
-} greatest_test_res;
-
 /* Global var for the current testing context.
  * Initialized by GREATEST_MAIN_DEFS(). */
 extern greatest_run_info greatest_info;
@@ -230,7 +223,7 @@ void greatest_do_pass(const char *name);
 void greatest_do_fail(const char *name);
 void greatest_do_skip(const char *name);
 int greatest_pre_test(const char *name);
-greatest_test_res greatest_save_context(void);
+int greatest_save_context(void);
 void greatest_post_test(const char *name, int res);
 void greatest_usage(const char *name);
 int greatest_do_assert_equal_t(const void *exp, const void *got,
@@ -253,6 +246,12 @@ int greatest_all_passed(void);
  * The arguments are not included, to allow parametric testing. */
 #define GREATEST_TEST static greatest_test_res
 
+/* PASS/FAIL/SKIP result from a test. Used internally. */
+typedef enum {
+    GREATEST_TEST_RES_PASS = 0,
+    GREATEST_TEST_RES_FAIL = -1,
+    GREATEST_TEST_RES_SKIP = 1
+} greatest_test_res;
 
 /* Run a suite. */
 #define GREATEST_RUN_SUITE(S_NAME) greatest_run_suite(S_NAME, #S_NAME)

--- a/greatest.h
+++ b/greatest.h
@@ -328,7 +328,7 @@ int greatest_all_passed(void);
 #define GREATEST_ASSERTm(MSG, COND)                                     \
     do {                                                                \
         greatest_info.assertions++;                                     \
-        if (!(COND)) { FAILm(MSG); }                                    \
+        if (!(COND)) { GREATEST_FAILm(MSG); }                                    \
     } while (0)
 
 /* Fail if a condition is not true, longjmping out of test. */
@@ -342,14 +342,14 @@ int greatest_all_passed(void);
 #define GREATEST_ASSERT_FALSEm(MSG, COND)                               \
     do {                                                                \
         greatest_info.assertions++;                                     \
-        if ((COND)) { FAILm(MSG); }                                     \
+        if ((COND)) { GREATEST_FAILm(MSG); }                                     \
     } while (0)
 
 /* Fail if EXP != GOT (equality comparison by ==). */
 #define GREATEST_ASSERT_EQm(MSG, EXP, GOT)                              \
     do {                                                                \
         greatest_info.assertions++;                                     \
-        if ((EXP) != (GOT)) { FAILm(MSG); }                             \
+        if ((EXP) != (GOT)) { GREATEST_FAILm(MSG); }                             \
     } while (0)
 
 /* Fail if EXP is not equal to GOT, according to strcmp. */
@@ -369,9 +369,9 @@ int greatest_all_passed(void);
         if (!greatest_do_assert_equal_t(EXP, GOT,                       \
                 type_info, UDATA)) {                                    \
             if (type_info == NULL || type_info->equal == NULL) {        \
-                FAILm("type_info->equal callback missing!");            \
+                GREATEST_FAILm("type_info->equal callback missing!");            \
             } else {                                                    \
-                FAILm(MSG);                                             \
+                GREATEST_FAILm(MSG);                                             \
             }                                                           \
         }                                                               \
     } while (0)                                                         \

--- a/greatest.h
+++ b/greatest.h
@@ -209,6 +209,13 @@ typedef struct greatest_run_info {
 #endif
 } greatest_run_info;
 
+/* PASS/FAIL/SKIP result from a test. Used internally. */
+typedef enum {
+    GREATEST_TEST_RES_PASS = 0,
+    GREATEST_TEST_RES_FAIL = -1,
+    GREATEST_TEST_RES_SKIP = 1
+} greatest_test_res;
+
 /* Global var for the current testing context.
  * Initialized by GREATEST_MAIN_DEFS(). */
 extern greatest_run_info greatest_info;
@@ -223,7 +230,7 @@ void greatest_do_pass(const char *name);
 void greatest_do_fail(const char *name);
 void greatest_do_skip(const char *name);
 int greatest_pre_test(const char *name);
-int greatest_save_context(void);
+greatest_test_res greatest_save_context(void);
 void greatest_post_test(const char *name, int res);
 void greatest_usage(const char *name);
 int greatest_do_assert_equal_t(const void *exp, const void *got,
@@ -246,12 +253,6 @@ int greatest_all_passed(void);
  * The arguments are not included, to allow parametric testing. */
 #define GREATEST_TEST static greatest_test_res
 
-/* PASS/FAIL/SKIP result from a test. Used internally. */
-typedef enum {
-    GREATEST_TEST_RES_PASS = 0,
-    GREATEST_TEST_RES_FAIL = -1,
-    GREATEST_TEST_RES_SKIP = 1
-} greatest_test_res;
 
 /* Run a suite. */
 #define GREATEST_RUN_SUITE(S_NAME) greatest_run_suite(S_NAME, #S_NAME)

--- a/greatest.h
+++ b/greatest.h
@@ -240,7 +240,7 @@ int greatest_all_passed(void);
  **********/
 
 /* Define a suite. */
-#define GREATEST_SUITE(NAME) void NAME(void)
+#define GREATEST_SUITE(NAME) void NAME(void); void NAME(void)
 
 /* Start defining a test function.
  * The arguments are not included, to allow parametric testing. */


### PR DESCRIPTION
Sorry, I've only just managed to give your longjmp()-based FAIL integration a try, and update the code that originally triggered it. While doing so (all looks good!), I noticed a few minor issues, which I've done my best to fix.

 * 8aadf2e, avoiding compile warnings for non-declared test suite functions isn't a bug as such, but does fix an annoyance when you have tha warning enabled with clang.
 * 81ec25c fixes a legit bug in my opinion. :-) I'm a little surprised that C compilers don't complain about it, but I guess enums and ints are treated the same. C++ compilers legitimately kick up a fuss though.
 * f32dd49 fixes problems when `#define GREATEST_USE_ABBREVS 0` is used. (prefixed macros only)