### PR TITLE
Clean up warnings, add SUITE_EXTERN(NAME).

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ with more information.
 
 Assert that `COND` evaluates to a true value.
 
-### `ASSERT_FALSE(COND)` and `ASSERT_FAILm(MSG, COND)`
+### `ASSERT_FALSE(COND)` and `ASSERT_FALSEm(MSG, COND)`
 
 Assert that `COND` evaluates to a false value.
 

--- a/greatest.h
+++ b/greatest.h
@@ -268,7 +268,7 @@ int greatest_all_passed(void);
 
 /* Define a suite. */
 #define GREATEST_SUITE(NAME) void NAME(void); void NAME(void)
-#define GREATEST_SUITE_DECL(NAME) void NAME(void)
+#define GREATEST_SUITE_EXTERN(NAME) void NAME(void)
 
 /* Start defining a test function.
  * The arguments are not included, to allow parametric testing. */
@@ -795,7 +795,7 @@ greatest_run_info greatest_info
 #if GREATEST_USE_ABBREVS
 #define TEST           GREATEST_TEST
 #define SUITE          GREATEST_SUITE
-#define SUITE_DECL     GREATEST_SUITE_DECL
+#define SUITE_EXTERN   GREATEST_SUITE_EXTERN
 #define RUN_TEST       GREATEST_RUN_TEST
 #define RUN_TEST1      GREATEST_RUN_TEST1
 #define RUN_SUITE      GREATEST_RUN_SUITE

--- a/greatest.h
+++ b/greatest.h
@@ -17,10 +17,10 @@
 #ifndef GREATEST_H
 #define GREATEST_H
 
-/* 0.11.1 + (ASSERT_EQ_FMT, ASSERT_IN_RANGEm, USE_CLOCK, VS2013) */
-#define GREATEST_VERSION_MAJOR 0
-#define GREATEST_VERSION_MINOR 11
-#define GREATEST_VERSION_PATCH 1
+/* 1.0.0 */
+#define GREATEST_VERSION_MAJOR 1
+#define GREATEST_VERSION_MINOR 0
+#define GREATEST_VERSION_PATCH 0
 
 /* A unit testing system for C, contained in 1 file.
  * It doesn't use dynamic allocation or depend on anything

--- a/greatest.h
+++ b/greatest.h
@@ -268,6 +268,7 @@ int greatest_all_passed(void);
 
 /* Define a suite. */
 #define GREATEST_SUITE(NAME) void NAME(void); void NAME(void)
+#define GREATEST_SUITE_DECL(NAME) void NAME(void)
 
 /* Start defining a test function.
  * The arguments are not included, to allow parametric testing. */
@@ -686,7 +687,7 @@ void greatest_usage(const char *name) {                                 \
         name);                                                          \
 }                                                                       \
                                                                         \
-int greatest_all_passed() { return (greatest_info.failed == 0); }       \
+int greatest_all_passed(void) { return (greatest_info.failed == 0); }   \
                                                                         \
 void GREATEST_SET_SETUP_CB(greatest_setup_cb *cb, void *udata) {        \
     greatest_info.setup = cb;                                           \
@@ -794,6 +795,7 @@ greatest_run_info greatest_info
 #if GREATEST_USE_ABBREVS
 #define TEST           GREATEST_TEST
 #define SUITE          GREATEST_SUITE
+#define SUITE_DECL     GREATEST_SUITE_DECL
 #define RUN_TEST       GREATEST_RUN_TEST
 #define RUN_TEST1      GREATEST_RUN_TEST1
 #define RUN_SUITE      GREATEST_RUN_SUITE


### PR DESCRIPTION
SUITE_EXTERN(NAME) lets you run SUITE(NAME) declared in a separate file; this is handy if you want to organize your test suites into several modules and provide one `main()` to act as a test driver.