### PR TITLE
Fix sign warning

### DIFF
--- a/greatest.h
+++ b/greatest.h
@@ -666,7 +666,7 @@ int greatest_do_assert_equal_t(const void *exp, const void *got,        \
             fprintf(GREATEST_STDOUT, "\n");                             \
         } else {                                                        \
             fprintf(GREATEST_STDOUT,                                    \
-                "GREATEST_ASSERT_EQUAL_T failure at %s:%dn",            \
+                "GREATEST_ASSERT_EQUAL_T failure at %s:%u\n",           \
                 greatest_info.fail_file,                                \
                 greatest_info.fail_line);                               \
         }                                                               \


### PR DESCRIPTION
Fixes #33, also I assume the `n` at the end of the line was supposed to be a newline.