### PR TITLE
Wconversion_compatibility

### DIFF
--- a/greatest.h
+++ b/greatest.h
@@ -993,7 +993,7 @@ void greatest_set_verbosity(unsigned int verbosity) {                   \
 }                                                                       \
                                                                         \
 void greatest_set_flag(greatest_flag_t flag) {                          \
-    greatest_info.flags |= flag;                                        \
+    greatest_info.flags = (unsigned char)(greatest_info.flags | flag);  \
 }                                                                       \
                                                                         \
 void greatest_set_test_suffix(const char *suffix) {                     \


### PR DESCRIPTION
When using `-Wconversion` flag this error shows up:
`error: conversion to 'unsigned char' from 'unsigned int' may alter its value [-Wconversion]`

The proposed small change silences this error, thus providing compatibility with this flag.