### PR TITLE
Fix 6 missing dependencies in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,17 +33,14 @@ example_no_suite: example_no_suite.o
 example_no_runner: example_no_runner.o
 example_shuffle: example_shuffle.o
 
-example_cpp: example_cpp.cpp
+example_cpp: example_cpp.cpp greatest.h
 	${CXX} -o $@ example_cpp.cpp ${CPPFLAGS} ${LDFLAGS}
 
-%.o: %.c
+%.o: %.c greatest.h Makefile
 	${CC} -c -o $@ ${CFLAGS} $<
 
 %: %.o
 	${CC} -o $@ ${LDFLAGS} $^
-
-*.o: Makefile
-*.o: greatest.h
 
 clean:
 	rm -f ${PROGRAMS_C} ${PROGRAMS_CPP} *.o *.core


### PR DESCRIPTION
Hi, I've fixed 6 dependencies missing reported.
Those issues can cause incorrect results when greatest is incrementally built.
For example, any changes in "greatest.h" will not cause "example_cpp" to be rebuilt, which is incorrect. Line 45 and 46 in the original Makefile did not work. Makefile and "greatest.h"  were not specified successfully as the prerequisites of *.o.
I've tested it on my computer, the fixed version worked as expected.
Looking forward to your confirmation.

Thanks
Vemake