### PR TITLE
Fix fault in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ example: example.o example_suite.o
 example_no_suite: example_no_suite.o
 example_no_runner: example_no_runner.o
 example_shuffle: example_shuffle.o
+example_trunc: example_trunc.o
 
 example_cpp: example_cpp.cpp
 	${CXX} -o $@ example_cpp.cpp ${CPPFLAGS} ${LDFLAGS}


### PR DESCRIPTION
Hi

This pull request fixes one fault in Makefile.

In particular, `example_trunc` depends on `greatest.h` but it is not re-generated whenever there are updates to that header file.

This commit fixes that issue.