### PR TITLE
Add ASSERT_NEQ

### DIFF
--- a/example.c
+++ b/example.c
@@ -30,6 +30,12 @@ TEST expect_equal(void) {
     PASS();
 }
 
+TEST expect_not_equal(void) {
+    int i = 9;
+    ASSERT_NE(10, i);
+    PASS();
+}
+
 TEST expect_str_equal(void) {
     const char *foo1 = "foo1";
     ASSERT_STR_EQ("foo2", foo1);
@@ -279,6 +285,7 @@ SUITE(suite) {
     printf("\nThis should fail:\n");
     RUN_TEST(expect_str_equal);
     printf("\nThis should pass:\n");
+    RUN_TEST(expect_not_equal);
     RUN_TEST(expect_strn_equal);
     printf("\nThis should fail:\n");
     RUN_TEST(expect_boxed_int_equal);

--- a/example.c
+++ b/example.c
@@ -32,7 +32,7 @@ TEST expect_equal(void) {
 
 TEST expect_not_equal(void) {
     int i = 9;
-    ASSERT_NE(10, i);
+    ASSERT_NEQ(10, i);
     PASS();
 }
 

--- a/greatest.h
+++ b/greatest.h
@@ -434,8 +434,8 @@ typedef enum greatest_test_res {
     GREATEST_ASSERT_FALSEm(#COND, COND)
 #define GREATEST_ASSERT_EQ(EXP, GOT)                                    \
     GREATEST_ASSERT_EQm(#EXP " != " #GOT, EXP, GOT)
-#define GREATEST_ASSERT_NE(EXP, GOT)                                    \
-    GREATEST_ASSERT_NEm(#EXP " == " #GOT, EXP, GOT)
+#define GREATEST_ASSERT_NEQ(EXP, GOT)                                   \
+    GREATEST_ASSERT_NEQm(#EXP " == " #GOT, EXP, GOT)
 #define GREATEST_ASSERT_EQ_FMT(EXP, GOT, FMT)                           \
     GREATEST_ASSERT_EQ_FMTm(#EXP " != " #GOT, EXP, GOT, FMT)
 #define GREATEST_ASSERT_IN_RANGE(EXP, GOT, TOL)                         \
@@ -483,7 +483,7 @@ typedef enum greatest_test_res {
     } while (0)
 
 /* Fail if EXP == GOT (equality comparison by !=). */
-#define GREATEST_ASSERT_NEm(MSG, EXP, GOT)                              \
+#define GREATEST_ASSERT_NEQm(MSG, EXP, GOT)                             \
     do {                                                                \
         greatest_info.assertions++;                                     \
         if ((EXP) == (GOT)) { GREATEST_FAILm(MSG); }                    \
@@ -1186,7 +1186,7 @@ greatest_run_info greatest_info
 #define ASSERTm        GREATEST_ASSERTm
 #define ASSERT_FALSE   GREATEST_ASSERT_FALSE
 #define ASSERT_EQ      GREATEST_ASSERT_EQ
-#define ASSERT_NE      GREATEST_ASSERT_NE
+#define ASSERT_NEQ     GREATEST_ASSERT_NEQ
 #define ASSERT_EQ_FMT  GREATEST_ASSERT_EQ_FMT
 #define ASSERT_IN_RANGE GREATEST_ASSERT_IN_RANGE
 #define ASSERT_EQUAL_T GREATEST_ASSERT_EQUAL_T
@@ -1196,7 +1196,7 @@ greatest_run_info greatest_info
 #define ASSERT_ENUM_EQ GREATEST_ASSERT_ENUM_EQ
 #define ASSERT_FALSEm  GREATEST_ASSERT_FALSEm
 #define ASSERT_EQm     GREATEST_ASSERT_EQm
-#define ASSERT_NEm     GREATEST_ASSERT_NEm
+#define ASSERT_NEQm    GREATEST_ASSERT_NEQm
 #define ASSERT_EQ_FMTm GREATEST_ASSERT_EQ_FMTm
 #define ASSERT_IN_RANGEm GREATEST_ASSERT_IN_RANGEm
 #define ASSERT_EQUAL_Tm GREATEST_ASSERT_EQUAL_Tm

--- a/greatest.h
+++ b/greatest.h
@@ -434,6 +434,8 @@ typedef enum greatest_test_res {
     GREATEST_ASSERT_FALSEm(#COND, COND)
 #define GREATEST_ASSERT_EQ(EXP, GOT)                                    \
     GREATEST_ASSERT_EQm(#EXP " != " #GOT, EXP, GOT)
+#define GREATEST_ASSERT_NE(EXP, GOT)                                    \
+    GREATEST_ASSERT_NEm(#EXP " == " #GOT, EXP, GOT)
 #define GREATEST_ASSERT_EQ_FMT(EXP, GOT, FMT)                           \
     GREATEST_ASSERT_EQ_FMTm(#EXP " != " #GOT, EXP, GOT, FMT)
 #define GREATEST_ASSERT_IN_RANGE(EXP, GOT, TOL)                         \
@@ -478,6 +480,13 @@ typedef enum greatest_test_res {
     do {                                                                \
         greatest_info.assertions++;                                     \
         if ((EXP) != (GOT)) { GREATEST_FAILm(MSG); }                    \
+    } while (0)
+
+/* Fail if EXP == GOT (equality comparison by !=). */
+#define GREATEST_ASSERT_NEm(MSG, EXP, GOT)                              \
+    do {                                                                \
+        greatest_info.assertions++;                                     \
+        if ((EXP) == (GOT)) { GREATEST_FAILm(MSG); }                    \
     } while (0)
 
 /* Fail if EXP != GOT (equality comparison by ==).
@@ -1177,6 +1186,7 @@ greatest_run_info greatest_info
 #define ASSERTm        GREATEST_ASSERTm
 #define ASSERT_FALSE   GREATEST_ASSERT_FALSE
 #define ASSERT_EQ      GREATEST_ASSERT_EQ
+#define ASSERT_NE      GREATEST_ASSERT_NE
 #define ASSERT_EQ_FMT  GREATEST_ASSERT_EQ_FMT
 #define ASSERT_IN_RANGE GREATEST_ASSERT_IN_RANGE
 #define ASSERT_EQUAL_T GREATEST_ASSERT_EQUAL_T
@@ -1186,6 +1196,7 @@ greatest_run_info greatest_info
 #define ASSERT_ENUM_EQ GREATEST_ASSERT_ENUM_EQ
 #define ASSERT_FALSEm  GREATEST_ASSERT_FALSEm
 #define ASSERT_EQm     GREATEST_ASSERT_EQm
+#define ASSERT_NEm     GREATEST_ASSERT_NEm
 #define ASSERT_EQ_FMTm GREATEST_ASSERT_EQ_FMTm
 #define ASSERT_IN_RANGEm GREATEST_ASSERT_IN_RANGEm
 #define ASSERT_EQUAL_Tm GREATEST_ASSERT_EQUAL_Tm


### PR DESCRIPTION
I often find myself wanting to check a result is non-`NULL`. This patch
adds `ASSERT_NEQ` so that it is simple to write `ASSERT_NEQ(result,
NULL)`, for example.