### PR TITLE
Explicitly casting flags to prevent warning in CLion

### DIFF
--- a/greatest.h
+++ b/greatest.h
@@ -413,11 +413,11 @@ typedef enum greatest_test_res {
 /* Check if the test runner is in verbose mode. */
 #define GREATEST_IS_VERBOSE() ((greatest_info.verbosity) > 0)
 #define GREATEST_LIST_ONLY()                                            \
-    (greatest_info.flags & GREATEST_FLAG_LIST_ONLY)
+    (greatest_info.flags & (unsigned char)GREATEST_FLAG_LIST_ONLY)
 #define GREATEST_FIRST_FAIL()                                           \
-    (greatest_info.flags & GREATEST_FLAG_FIRST_FAIL)
+    (greatest_info.flags & (unsigned char)GREATEST_FLAG_FIRST_FAIL)
 #define GREATEST_ABORT_ON_FAIL()                                        \
-    (greatest_info.flags & GREATEST_FLAG_ABORT_ON_FAIL)
+    (greatest_info.flags & (unsigned char)GREATEST_FLAG_ABORT_ON_FAIL)
 #define GREATEST_FAILURE_ABORT()                                        \
     (GREATEST_FIRST_FAIL() &&                                           \
         (greatest_info.suite.failed > 0 || greatest_info.failed > 0))


### PR DESCRIPTION
Hey Scott, :wave:

first of all thank you for creating this neat testing framework - it's a pleasure to use!

I noticed that in CLion, the following warning is issued for each assertion used in the test sourcecode.

> Clang-Tidy: Use of a signed integer operand with a binary bitwise operator

I was able to track it down to the `GREATEST_LIST_ONLY()`, `GREATEST_FIRST_FAIL()` and `GREATEST_ABORT_ON_FAIL()` macroes, where introducing a cast to `unsigned char` fixes the problem (see PR).

Regards,
Lucas