### PR TITLE
docs: fix simple typo, seperately -> separately

### DIFF
--- a/example.c
+++ b/example.c
@@ -4,7 +4,7 @@
 
 #include "greatest.h"
 
-/* Define a suite, compiled seperately. */
+/* Define a suite, compiled separately. */
 SUITE_EXTERN(other_suite);
 
 /* Declare a local suite. */


### PR DESCRIPTION
There is a small typo in example.c.

Should read `separately` rather than `seperately`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md