### PR TITLE
Fix range handling of GREATEST_ASSERT_IN_RANGE.

### DIFF
--- a/greatest.h
+++ b/greatest.h
@@ -538,10 +538,9 @@ typedef enum greatest_test_res {
         GREATEST_FLOAT greatest_GOT = (GOT);                            \
         GREATEST_FLOAT greatest_TOL = (TOL);                            \
         greatest_info.assertions++;                                     \
-        if ((greatest_EXP > greatest_GOT &&                             \
-                greatest_EXP - greatest_GOT > greatest_TOL) ||          \
-            (greatest_EXP < greatest_GOT &&                             \
-                greatest_GOT - greatest_EXP > greatest_TOL)) {          \
+        if (!(                                                          \
+            greatest_GOT >= greatest_EXP - greatest_TOL &&              \
+            greatest_GOT <= greatest_EXP + greatest_TOL)) {             \
             GREATEST_FPRINTF(GREATEST_STDOUT,                           \
                 "\nExpected: " GREATEST_FLOAT_FMT                       \
                 " +/- " GREATEST_FLOAT_FMT                              \


### PR DESCRIPTION
Now `ASSERT_IN_RANGE(1, NAN, 1e-6)` properly fails. See issue #108 for details. Besides code review, is there anything that needs to be done to make sure that this change is correct?