### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,16 @@ For example, a test or suite named `main` will have a name collision.
 
 (For more examples, look at `example.c` and `example_suite.c`.)
 
+## Installing greatest (vcpkg) 
+Alternatively, you can build and install greatest using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+```sh or powershell
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh # "./bootstrap-vcpkg.bat" for Powershell
+    ./vcpkg integrate install
+    ./vcpkg install greatest
+```
+The greatest port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 ## Filtering By Name
 


### PR DESCRIPTION
`greatest` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `greatest` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `greatest`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/greatest/portfile.cmake). We try to keep the library maintained as close as possible to the original library.  :)