### PR TITLE
Fix __STDC_VERSION__ check for C99

### DIFF
--- a/example.c
+++ b/example.c
@@ -162,7 +162,7 @@ TEST parametric_example_c89(void *closure) {
 
 /* If using C99, greatest can also do parametric tests without
  * needing to manually manage a closure. */
-#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 19901L
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
 TEST parametric_example_c99(int arg) {
     ASSERT(arg > 10);
     PASS();
@@ -388,7 +388,7 @@ SUITE(suite) {
     RUN_TEST1(parametric_example_c89, &arg);
 
     /* Run a test, with arguments. ('p' for "parametric".) */
-#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 19901L
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
     printf("\nThis should fail:\n");
     RUN_TESTp(parametric_example_c99, 10);
     RUN_TESTp(parametric_example_c99, 11);
@@ -401,7 +401,7 @@ SUITE(suite) {
 #endif
 
 #if GREATEST_USE_LONGJMP &&                                     \
-    (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 19901L)
+    (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L)
     RUN_TESTp(fail_via_FAIL_WITH_LONGJMP_if_0, 0);
 #endif
 

--- a/greatest.h
+++ b/greatest.h
@@ -339,7 +339,7 @@ void greatest_set_test_suffix(const char *suffix);
 
 /* If __VA_ARGS__ (C99) is supported, allow parametric testing
 * without needing to manually manage the argument struct. */
-#if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 19901L) ||        \
+#if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L) ||       \
     (defined(_MSC_VER) && _MSC_VER >= 1800)
 #define GREATEST_VA_ARGS
 #endif


### PR DESCRIPTION
The correct value for C99 is `199901L` (1999/01).